### PR TITLE
Remove compilation flag for MacOS-only limitation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,6 @@
 #![allow(non_snake_case, non_upper_case_globals)]
 #![deny(missing_docs, unused_import_braces, unused_qualifications)]
 
-#[cfg(not(target_os = "macos"))]
-compile_error!("This crate presently only compiles on macOS (see GH issue #5 for iOS support)");
-
 #[macro_use]
 extern crate core_foundation;
 


### PR DESCRIPTION
This PR removes the compile error that doesn't allow building for other targets other than the MacOS. iOS didn't have that API support at that time, but it has now; thus, that limitation is not required anymore.

TODO in the separate request: Figure out the exact list of targets for which we want to have an exception.